### PR TITLE
HD-5: Update npm

### DIFF
--- a/app/php84.Dockerfile
+++ b/app/php84.Dockerfile
@@ -22,7 +22,7 @@ ENV PATH="${PATH}:/root/.composer/vendor/bin"
 
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
-    && npm install -g npm@10.x
+    && npm install -g npm@latest
 
 RUN composer global require laravel/installer && \
     chmod +x /root/.composer/vendor/bin/laravel


### PR DESCRIPTION
Updated the Dockerfile to install the latest npm version instead of a specific range (npm@10.x). This ensures the container always uses the most up-to-date version of npm.